### PR TITLE
Add more configuration options: host and port

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ Note: These can also be set using Docker [.env files](https://docs.docker.com/co
   - Default: `[]` (empty array)
 
 ### Environment
+- `VOD2POD_RSS_HOST`: Set the host address to bind to (default: "0.0.0.0")
+- `VOD2POD_RSS_PORT`: Set the port to listen on (default: "8080")
+- `TEMPLATES_DIR`: Set the directory for template files (default: "./templates")
 - `TRANSCODE`: Set to "false" to disable transcoding, usefull if you only need the feeds (default: "true")
 - `MP3_BITRATE`: Set the bitrate of the trascoded stream to your client (default: "192")
 - `SUBFOLDER`: Set the the root path of the app, useful for reverse proxies (default: "/")

--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ Note: These can also be set using Docker [.env files](https://docs.docker.com/co
 ### Environment
 - `VOD2POD_RSS_HOST`: Set the host address to bind to (default: "0.0.0.0")
 - `VOD2POD_RSS_PORT`: Set the port to listen on (default: "8080")
-- `TEMPLATES_DIR`: Set the directory for template files (default: "./templates")
 - `TRANSCODE`: Set to "false" to disable transcoding, usefull if you only need the feeds (default: "true")
 - `MP3_BITRATE`: Set the bitrate of the trascoded stream to your client (default: "192")
 - `SUBFOLDER`: Set the the root path of the app, useful for reverse proxies (default: "/")

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -26,6 +26,9 @@ pub enum ConfName {
     YoutubeYtDlpExtraArgs,
     CacheTTL,
     FfmpegTimeoutSeconds,
+    TemplatesDir,
+    Host,
+    Port,
 }
 
 struct EnvConf {}
@@ -118,6 +121,15 @@ impl Conf for EnvConf {
             }
             ConfName::FfmpegTimeoutSeconds => {
                 Ok(std::env::var("FFMPEG_TIMEOUT_SECONDS").unwrap_or_else(|_| "300".to_string()))
+            }
+            ConfName::TemplatesDir => {
+                Ok(std::env::var("TEMPLATES_DIR").unwrap_or_else(|_| "./templates".to_string()))
+            }
+            ConfName::Host => {
+                Ok(std::env::var("VOD2POD_RSS_HOST").unwrap_or_else(|_| "0.0.0.0".to_string()))
+            }
+            ConfName::Port => {
+                Ok(std::env::var("VOD2POD_RSS_PORT").unwrap_or_else(|_| "8080".to_string()))
             }
         }
     }

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -26,7 +26,6 @@ pub enum ConfName {
     YoutubeYtDlpExtraArgs,
     CacheTTL,
     FfmpegTimeoutSeconds,
-    TemplatesDir,
     Host,
     Port,
 }
@@ -121,9 +120,6 @@ impl Conf for EnvConf {
             }
             ConfName::FfmpegTimeoutSeconds => {
                 Ok(std::env::var("FFMPEG_TIMEOUT_SECONDS").unwrap_or_else(|_| "300".to_string()))
-            }
-            ConfName::TemplatesDir => {
-                Ok(std::env::var("TEMPLATES_DIR").unwrap_or_else(|_| "./templates".to_string()))
             }
             ConfName::Host => {
                 Ok(std::env::var("VOD2POD_RSS_HOST").unwrap_or_else(|_| "0.0.0.0".to_string()))

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,10 @@
 use log::{debug, info};
 use simple_logger::SimpleLogger;
 use std::{env, net::TcpListener, process::exit};
-use vod2pod_rss::server;
+use vod2pod_rss::{
+    configs::{conf, Conf, ConfName},
+    server,
+};
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
@@ -25,7 +28,15 @@ async fn main() -> std::io::Result<()> {
         );
     }
 
-    let listener = TcpListener::bind("0.0.0.0:8080").expect("Failed to bind");
+    let host = conf()
+        .get(ConfName::Host)
+        .unwrap_or_else(|_| "0.0.0.0".to_string());
+    let port = conf()
+        .get(ConfName::Port)
+        .unwrap_or_else(|_| "8080".to_string());
+    let bind_addr = format!("{}:{}", host, port);
+
+    let listener = TcpListener::bind(&bind_addr).expect("Failed to bind");
     info!("listening on http://{}", listener.local_addr().unwrap());
     server::spawn_server(listener)
         .expect("could not setup server")
@@ -61,4 +72,3 @@ async fn flush_redis_on_new_version() -> eyre::Result<()> {
 
     Ok(())
 }
-

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -67,7 +67,11 @@ async fn index(req: HttpRequest) -> HttpResponse {
         );
     }
 
-    let html = std::fs::read_to_string("./templates/index.html").unwrap();
+    let templates_dir = conf()
+        .get(ConfName::TemplatesDir)
+        .unwrap_or_else(|_| "./templates".to_string());
+    let html = std::fs::read_to_string(format!("{}/index.html", templates_dir)).unwrap();
+
     HttpResponse::Ok().content_type("text/html").body(html)
 }
 async fn transcodize_rss(

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -67,10 +67,7 @@ async fn index(req: HttpRequest) -> HttpResponse {
         );
     }
 
-    let templates_dir = conf()
-        .get(ConfName::TemplatesDir)
-        .unwrap_or_else(|_| "./templates".to_string());
-    let html = std::fs::read_to_string(format!("{}/index.html", templates_dir)).unwrap();
+    let html = std::fs::read_to_string("./templates/index.html").unwrap();
 
     HttpResponse::Ok().content_type("text/html").body(html)
 }


### PR DESCRIPTION
Add 3 more environment variables read by vod2pod-rss:
- `VOD2POD_RSS_HOST`: host used for binding
- `VOD2POD_RSS_PORT`: port used for binding

There are default values to maintain previous behavior.