### PR TITLE
fix: make transcoded downloads HTTP range compliant

### DIFF
--- a/src/rss_transcodizer/mod.rs
+++ b/src/rss_transcodizer/mod.rs
@@ -9,6 +9,7 @@ use rss::Channel;
 use rss::{Enclosure, Item};
 
 use crate::configs::{conf, AudioCodec, Conf, ConfName};
+use crate::transcoder::estimated_output_bytes;
 
 pub fn inject_vod2pod_customizations(
     rss_body: String,
@@ -67,7 +68,7 @@ pub fn inject_vod2pod_customizations(
                     .append_pair("ext", ext.as_str()); //this should allways be last, some players refuse to play urls not ending in .mp3
 
                 let enclosure = Enclosure {
-                    length: (bitrate * 1024 * duration_secs).to_string(),
+                    length: estimated_output_bytes(*duration_secs, bitrate).to_string(),
                     url: transcode_service_url.to_string(),
                     mime_type: "audio/mpeg".to_string(),
                 };
@@ -128,3 +129,33 @@ fn parse_duration(duration_str: &str) -> Result<Duration, String> {
     Ok(Duration::from_secs(duration_secs))
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enclosure_length_matches_the_streamed_byte_count() {
+        let raw_rss = r#"<?xml version="1.0" encoding="UTF-8"?>
+            <rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+                <channel>
+                    <title>Test feed</title>
+                    <link>https://www.youtube.com/</link>
+                    <description>Test feed</description>
+                    <item>
+                        <title>Test episode</title>
+                        <link>https://www.youtube.com/watch?v=test</link>
+                        <itunes:duration>00:02:36</itunes:duration>
+                    </item>
+                </channel>
+            </rss>"#;
+
+        let result = inject_vod2pod_customizations(
+            raw_rss.to_string(),
+            Some(Url::parse("http://localhost/transcode_media/to.mp3").unwrap()),
+        )
+        .unwrap();
+        let channel = Channel::read_from(result.as_bytes()).unwrap();
+
+        assert_eq!(channel.items[0].enclosure().unwrap().length(), "3744000");
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,10 +1,10 @@
 use std::{collections::HashMap, net::TcpListener, time::Instant};
 
 use actix_web::{
-    dev::Server, guard, http, middleware, web, App, HttpRequest, HttpResponse, HttpServer,
+    dev::Server, guard, http, middleware, web, App, HttpRequest, HttpResponse, HttpResponseBuilder,
+    HttpServer,
 };
 use log::{debug, error, info, warn};
-use regex::Regex;
 use serde::Deserialize;
 use url::Url;
 
@@ -12,7 +12,7 @@ use crate::{
     configs::{conf, Conf, ConfName},
     provider::{self, MediaProvider},
     rss_transcodizer,
-    transcoder::{FfmpegParameters, Transcoder},
+    transcoder::{estimated_output_bytes, FfmpegParameters, Transcoder},
 };
 
 pub fn spawn_server(listener: TcpListener) -> eyre::Result<Server> {
@@ -187,49 +187,89 @@ struct TranscodizeQuery {
     duration: usize,
 }
 
-fn parse_range_header(
-    content_range_str: &str,
-    bytes_count: usize,
-) -> eyre::Result<(usize, usize, usize)> {
-    let re = Regex::new(r"(?P<start>[0-9]{1,20})-?(?P<end>[0-9]{1,20})?")?;
-    let captures = if let Some(x) = re.captures_iter(content_range_str).next() {
-        x
-    } else {
-        return Err(eyre::eyre!("content range regex failed"));
+#[derive(Debug, PartialEq)]
+enum RangeError {
+    Invalid,
+    Unsatisfiable,
+}
+
+fn parse_range_header(range_header: &str, bytes_count: u64) -> Result<(u64, u64, u64), RangeError> {
+    if bytes_count == 0 {
+        return Err(RangeError::Unsatisfiable);
+    }
+
+    let range = range_header
+        .trim()
+        .strip_prefix("bytes=")
+        .ok_or(RangeError::Invalid)?;
+    if range.contains(',') {
+        return Err(RangeError::Invalid);
+    }
+
+    let (start, end) = range.split_once('-').ok_or(RangeError::Invalid)?;
+    let (start, end) = match (start, end) {
+        ("", "") => return Err(RangeError::Invalid),
+        ("", suffix) => {
+            let suffix = suffix.parse::<u64>().map_err(|_| RangeError::Invalid)?;
+            if suffix == 0 {
+                return Err(RangeError::Invalid);
+            }
+            (bytes_count.saturating_sub(suffix), bytes_count - 1)
+        }
+        (start, "") => {
+            let start = start.parse::<u64>().map_err(|_| RangeError::Invalid)?;
+            if start >= bytes_count {
+                return Err(RangeError::Unsatisfiable);
+            }
+            (start, bytes_count - 1)
+        }
+        (start, end) => {
+            let start = start.parse::<u64>().map_err(|_| RangeError::Invalid)?;
+            let end = end.parse::<u64>().map_err(|_| RangeError::Invalid)?;
+            if start >= bytes_count || end < start {
+                return Err(RangeError::Unsatisfiable);
+            }
+            (start, end.min(bytes_count - 1))
+        }
     };
 
-    let mut start = 0;
-    if let Some(x) = captures.name("start") {
-        start = x.as_str().parse()?;
-    }
+    Ok((start, end, end - start + 1))
+}
 
-    if bytes_count == 0 {
-        error!("The requested Rage header with a length of 0 is invalid: {content_range_str}");
-        return Err(eyre::eyre!(
-            "The requested Rage header with a length of 0 is invalid: {content_range_str}"
+fn media_response_builder(
+    is_partial: bool,
+    start_bytes: u64,
+    end_bytes: u64,
+    total_bytes: u64,
+    content_length: u64,
+    content_type: &str,
+) -> HttpResponseBuilder {
+    let mut response = if is_partial {
+        HttpResponse::PartialContent()
+    } else {
+        HttpResponse::Ok()
+    };
+
+    response
+        .insert_header((http::header::ACCEPT_RANGES, "bytes"))
+        .insert_header((http::header::CONTENT_LENGTH, content_length.to_string()))
+        .content_type(content_type);
+
+    if is_partial {
+        response.insert_header((
+            http::header::CONTENT_RANGE,
+            format!("bytes {start_bytes}-{end_bytes}/{total_bytes}"),
         ));
     }
-    let mut end = bytes_count - 1;
-    if let Some(x) = captures.name("end") {
-        end = x.as_str().parse()?;
-    }
 
-    if end == start {
-        return Err(eyre::eyre!(
-            "The requested Rage header with a length of 0 is invalid: {content_range_str}"
-        ));
-    }
-
-    let expected = (end + 1) - start;
-
-    Ok((start, end, expected))
+    response
 }
 
 async fn transcode_to_mp3(req: HttpRequest, query: web::Query<TranscodizeQuery>) -> HttpResponse {
     let stream_url = &query.url;
     let bitrate = query.bitrate;
     let duration_secs = query.duration;
-    let total_streamable_bytes = (duration_secs * bitrate * 1000) / 8;
+    let total_streamable_bytes = estimated_output_bytes(duration_secs as u64, bitrate as u64);
     info!("processing transcode at {bitrate}k for {stream_url}");
 
     if let Ok(value) = conf().get(ConfName::TranscodingEnabled) {
@@ -249,29 +289,35 @@ async fn transcode_to_mp3(req: HttpRequest, query: web::Query<TranscodizeQuery>)
         return HttpResponse::Forbidden().body("scheme and host not in whitelist");
     }
 
-    // Range header parsing
-    const DEFAULT_CONTENT_RANGE: &str = "0-";
-    let content_range_str = match req.headers().get("Range") {
-        Some(x) => x.to_str().unwrap_or_default(),
-        None => DEFAULT_CONTENT_RANGE,
+    let range_header = req.headers().get(http::header::RANGE);
+    let is_partial = range_header.is_some();
+    let (start_bytes, end_bytes, expected_bytes) = match range_header {
+        Some(value) => match value
+            .to_str()
+            .map_err(|_| RangeError::Invalid)
+            .and_then(|value| parse_range_header(value, total_streamable_bytes))
+        {
+            Ok(range) => range,
+            Err(RangeError::Invalid) => return HttpResponse::BadRequest().finish(),
+            Err(RangeError::Unsatisfiable) => {
+                return HttpResponse::RangeNotSatisfiable()
+                    .insert_header((
+                        http::header::CONTENT_RANGE,
+                        format!("bytes */{total_streamable_bytes}"),
+                    ))
+                    .finish()
+            }
+        },
+        None if total_streamable_bytes > 0 => {
+            (0, total_streamable_bytes - 1, total_streamable_bytes)
+        }
+        None => return HttpResponse::NoContent().finish(),
     };
-
-    debug!("received content range {content_range_str}");
-
-    let (start_bytes, end_bytes, expected_bytes) =
-        match parse_range_header(content_range_str, total_streamable_bytes) {
-            Ok((start, end, expected)) => (start, end, expected),
-            Err(e) => return HttpResponse::BadRequest().body(e.to_string()),
-        };
 
     debug!("requested content-range: bytes {start_bytes}-{end_bytes}/{total_streamable_bytes}");
 
-    if start_bytes > end_bytes || start_bytes > total_streamable_bytes {
-        return HttpResponse::RangeNotSatisfiable().finish();
-    }
-
     let seek_secs =
-        ((start_bytes as f32) / (total_streamable_bytes as f32)) * (duration_secs as f32);
+        ((start_bytes as f64) / (total_streamable_bytes as f64)) * (duration_secs as f64);
     debug!("choosen seek_time: {seek_secs}");
 
     let timeout_in_seconds = conf()
@@ -283,46 +329,44 @@ async fn transcode_to_mp3(req: HttpRequest, query: web::Query<TranscodizeQuery>)
 
     let codec = conf().get(ConfName::AudioCodec).unwrap().into();
     let ffmpeg_paramenters = FfmpegParameters {
-        seek_time: seek_secs,
+        seek_time: seek_secs as f32,
         url: stream_url.clone(),
         audio_codec: codec,
         bitrate_kbit: bitrate,
         max_rate_kbit: bitrate * 30,
-        expected_bytes_count: expected_bytes,
+        expected_bytes_count: match expected_bytes.try_into() {
+            Ok(expected_bytes) => expected_bytes,
+            Err(_) => return HttpResponse::InternalServerError().finish(),
+        },
         timeout_in_seconds: timeout_in_seconds,
     };
     debug!("seconds: {duration_secs}, bitrate: {bitrate}");
 
     if req.method() == http::Method::HEAD {
-        return HttpResponse::Ok()
-            .insert_header(("Accept-Ranges", "bytes"))
-            .insert_header((
-                "Content-Range",
-                format!("bytes {start_bytes}-{end_bytes}/{total_streamable_bytes}"),
-            ))
-            .content_type(codec.get_mime_type_str())
-            .finish();
+        return media_response_builder(
+            is_partial,
+            start_bytes,
+            end_bytes,
+            total_streamable_bytes,
+            expected_bytes,
+            codec.get_mime_type_str(),
+        )
+        .finish();
     }
 
     match Transcoder::new(&ffmpeg_paramenters).await {
         Ok(transcoder) => {
             let stream = transcoder.get_transcode_stream();
 
-            let mut response_builder = if ffmpeg_paramenters.seek_time <= 0.1 {
-                HttpResponse::Ok()
-            } else {
-                HttpResponse::PartialContent()
-            };
-
-            response_builder
-                .insert_header(("Accept-Ranges", "bytes"))
-                .insert_header((
-                    "Content-Range",
-                    format!("bytes {start_bytes}-{end_bytes}/{total_streamable_bytes}"),
-                ))
-                .content_type(codec.get_mime_type_str())
-                .no_chunking((expected_bytes).try_into().unwrap())
-                .streaming(stream)
+            media_response_builder(
+                is_partial,
+                start_bytes,
+                end_bytes,
+                total_streamable_bytes,
+                expected_bytes,
+                codec.get_mime_type_str(),
+            )
+            .streaming(stream)
         }
         Err(e) => HttpResponse::ServiceUnavailable().body(e.to_string()),
     }
@@ -362,5 +406,61 @@ mod tests {
         let bytes_count = 200;
         let (start, end, expected) = parse_range_header(content_range_str, bytes_count).unwrap();
         assert_eq!((start, end, expected), (0, 199, 200));
+    }
+
+    #[test]
+    fn test_get_single_byte_range() {
+        assert_eq!(parse_range_header("bytes=0-0", 100), Ok((0, 0, 1)));
+    }
+
+    #[test]
+    fn test_get_suffix_range() {
+        assert_eq!(parse_range_header("bytes=-25", 100), Ok((75, 99, 25)));
+    }
+
+    #[test]
+    fn test_range_end_is_clamped_to_content_length() {
+        assert_eq!(parse_range_header("bytes=75-200", 100), Ok((75, 99, 25)));
+    }
+
+    #[test]
+    fn test_range_start_beyond_content_is_unsatisfiable() {
+        assert_eq!(
+            parse_range_header("bytes=100-", 100),
+            Err(RangeError::Unsatisfiable)
+        );
+    }
+
+    #[test]
+    fn full_response_has_content_length_without_content_range() {
+        let response = media_response_builder(false, 0, 99, 100, 100, "audio/mpeg").finish();
+
+        assert_eq!(response.status(), http::StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(http::header::CONTENT_LENGTH)
+                .unwrap(),
+            "100"
+        );
+        assert!(!response.headers().contains_key(http::header::CONTENT_RANGE));
+    }
+
+    #[test]
+    fn partial_response_has_range_status_and_headers() {
+        let response = media_response_builder(true, 0, 0, 100, 1, "audio/mpeg").finish();
+
+        assert_eq!(response.status(), http::StatusCode::PARTIAL_CONTENT);
+        assert_eq!(
+            response
+                .headers()
+                .get(http::header::CONTENT_LENGTH)
+                .unwrap(),
+            "1"
+        );
+        assert_eq!(
+            response.headers().get(http::header::CONTENT_RANGE).unwrap(),
+            "bytes 0-0/100"
+        );
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,9 +1,10 @@
 use std::{collections::HashMap, net::TcpListener, time::Instant};
 
 use actix_web::{
-    dev::Server, guard, http, middleware, web, App, HttpRequest, HttpResponse, HttpResponseBuilder,
-    HttpServer,
+    body::SizedStream, dev::Server, guard, http, middleware, web, App, HttpRequest, HttpResponse,
+    HttpResponseBuilder, HttpServer,
 };
+use futures::stream;
 use log::{debug, error, info, warn};
 use serde::Deserialize;
 use url::Url;
@@ -265,6 +266,11 @@ fn media_response_builder(
     response
 }
 
+fn head_media_response(mut response: HttpResponseBuilder, content_length: u64) -> HttpResponse {
+    let empty_body = stream::empty::<Result<web::Bytes, actix_web::Error>>();
+    response.body(SizedStream::new(content_length, empty_body))
+}
+
 async fn transcode_to_mp3(req: HttpRequest, query: web::Query<TranscodizeQuery>) -> HttpResponse {
     let stream_url = &query.url;
     let bitrate = query.bitrate;
@@ -343,15 +349,17 @@ async fn transcode_to_mp3(req: HttpRequest, query: web::Query<TranscodizeQuery>)
     debug!("seconds: {duration_secs}, bitrate: {bitrate}");
 
     if req.method() == http::Method::HEAD {
-        return media_response_builder(
-            is_partial,
-            start_bytes,
-            end_bytes,
-            total_streamable_bytes,
+        return head_media_response(
+            media_response_builder(
+                is_partial,
+                start_bytes,
+                end_bytes,
+                total_streamable_bytes,
+                expected_bytes,
+                codec.get_mime_type_str(),
+            ),
             expected_bytes,
-            codec.get_mime_type_str(),
-        )
-        .finish();
+        );
     }
 
     match Transcoder::new(&ffmpeg_paramenters).await {
@@ -375,6 +383,7 @@ async fn transcode_to_mp3(req: HttpRequest, query: web::Query<TranscodizeQuery>)
 #[cfg(test)]
 mod tests {
     use super::*;
+    use actix_web::body::{BodySize, MessageBody};
 
     #[test]
     fn test_get_start_and_end_start_to_end() {
@@ -462,5 +471,15 @@ mod tests {
             response.headers().get(http::header::CONTENT_RANGE).unwrap(),
             "bytes 0-0/100"
         );
+    }
+
+    #[test]
+    fn head_response_preserves_the_declared_body_size() {
+        let response = head_media_response(
+            media_response_builder(false, 0, 99, 100, 100, "audio/mpeg"),
+            100,
+        );
+
+        assert_eq!(response.body().size(), BodySize::Sized(100));
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -252,7 +252,7 @@ fn media_response_builder(
 
     response
         .insert_header((http::header::ACCEPT_RANGES, "bytes"))
-        .insert_header((http::header::CONTENT_LENGTH, content_length.to_string()))
+        .no_chunking(content_length)
         .content_type(content_type);
 
     if is_partial {

--- a/src/transcoder/mod.rs
+++ b/src/transcoder/mod.rs
@@ -20,6 +20,13 @@ use crate::configs::AudioCodec;
 use crate::provider;
 use crate::provider::MediaProvider;
 
+pub fn estimated_output_bytes(duration_secs: u64, bitrate_kbit: u64) -> u64 {
+    duration_secs
+        .saturating_mul(bitrate_kbit)
+        .saturating_mul(1000)
+        / 8
+}
+
 #[derive(Serialize)]
 pub struct FfmpegParameters {
     pub seek_time: f32,


### PR DESCRIPTION
## Summary

- make transcoded media responses advertise the actual estimated byte length
- support standard single HTTP byte ranges, including suffix and open-ended ranges
- return correct `HEAD`, `206 Partial Content`, and `416 Range Not Satisfiable` headers
- share the output-size calculation with RSS enclosure generation

The stream remains generated on demand and is not cached or persisted on disk.

Fixes #375

## Tests

- `cargo test server::tests`
- `cargo test enclosure_length_matches_the_streamed_byte_count`
- `cargo test transcoder::test::check_ffmpeg_command`

`cargo test --lib` also passed all relevant local tests; eight pre-existing provider integration tests require external YouTube/Twitch API keys and failed without those credentials.
